### PR TITLE
Fix "Trying to get property 'id' of non-object" error when editing user without roles

### DIFF
--- a/src/resources/views/usersmanagement/edit-user.blade.php
+++ b/src/resources/views/usersmanagement/edit-user.blade.php
@@ -108,7 +108,11 @@
                                             <option value="">{{ trans('laravelusers::forms.create_user_ph_role') }}</option>
                                             @if ($roles)
                                                 @foreach($roles as $role)
-                                                    <option value="{{ $role->id }}" {{ $currentRole->id == $role->id ? 'selected="selected"' : '' }}>{{ $role->name }}</option>
+                                                    @if ($currentRole)
+                                                        <option value="{{ $role->id }}" {{ $currentRole->id == $role->id ? 'selected="selected"' : '' }}>{{ $role->name }}</option>
+                                                    @else
+                                                        <option value="{{ $role->id }}">{{ $role->name }}</option>
+                                                    @endif
                                                 @endforeach
                                             @endif
                                         </select>


### PR DESCRIPTION
When opening the edit view for a user without a current role, the error "Trying to get property 'id' of non-object" will be thrown. This is quite simply because the view is trying to retrieve `$currentRole->id`, while `$currentRole` is an empty string or null if no role has been found.

My solution may not be the most elegant solution, so I understand if you reject this pull request in favour of another solution.

_Also this is my first ever public pull request, so my apologies if I am not following all the proper protocols._